### PR TITLE
gitignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I have a dotfiles repository that has vim-headerguard as a git submodule.

Running `:helptags` generates `doc/tags`, which shows-up as untracked content of the submodule.